### PR TITLE
Restructure the Dockerfile to use a separate building stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,48 @@
+FROM minizinc/minizinc AS BUILDER
+
+ARG VERSION="7.8"
+ARG REV="7959"
+
+# Install temporary dependencies
+RUN apt-get update
+RUN apt-get install wget -y
+
+# Download OR-Tools Release
+RUN echo "Yass $VERSION"
+RUN wget https://github.com/google/or-tools/releases/download/v${VERSION}/or-tools_flatzinc_ubuntu-18.04_v${VERSION}.${REV}.tar.gz
+RUN tar -xzvf or-tools_flatzinc_ubuntu-18.04_v${VERSION}.${REV}.tar.gz
+
+# Setup Binary files
+RUN mkdir /ortools
+RUN ls -lah
+RUN mv or-tools_flatzinc_Ubuntu-18.04-64bit_v${VERSION}.${REV}/bin or-tools_flatzinc_Ubuntu-18.04-64bit_v${VERSION}.${REV}/lib /ortools
+
+# Setup OR-Tools MiniZinc library
+RUN mkdir -p /ortools/share/minizinc/ortools
+RUN mv or-tools_flatzinc_Ubuntu-18.04-64bit_v${VERSION}.${REV}/share/minizinc/* /ortools/share/minizinc/ortools/
+
+# Add OR-Tools solver configuration
+RUN mkdir -p /ortools/share/minizinc/solvers
+RUN echo "{ \n\
+  \"id\": \"com.google.or-tools\",\n\
+  \"name\": \"OR-Tools\",\n\
+  \"description\": \"OR Tools Constraint Programming Solver (from Google)\",\n\
+  \"version\": \"${VERSION}.${REV}\",\n\
+  \"mznlib\": \"-Gortools\",\n\
+  \"executable\": \"../../../bin/fzn-or-tools\",\n\
+  \"tags\": [\"cp\",\"int\", ],\n\
+  \"stdFlags\": [\"-a\",\"-n\",\"-s\",\"-v\",\"-p\",\"-f\",\"-t\"],\n\
+  \"supportsMzn\": false,\n\
+  \"supportsFzn\": true,\n\
+  \"needsSolns2Out\": true,\n\
+  \"needsMznExecutable\": false,\n\
+  \"needsStdlibDir\": false,\n\
+  \"isGUIApplication\": false \n\
+}" >> /ortools/share/minizinc/solvers/or-tools.msc
+
+# Set OR-Tools as default MiniZinc solver
+RUN sed 's/org\.gecode\.gecode/com\.google\.or-tools/g' /usr/local/share/minizinc/Preferences.json > /ortools/share/minizinc/Preferences.json
+
 FROM minizinc/minizinc
 
-RUN apt-get update && apt-get install wget -y && wget https://github.com/google/or-tools/releases/download/v7.6/or-tools_flatzinc_ubuntu-18.04_v7.6.7691.tar.gz && apt-get purge wget -y && tar -xzvf or-tools_flatzinc_ubuntu-18.04_v7.6.7691.tar.gz && rm or-tools_flatzinc_ubuntu-18.04_v7.6.7691.tar.gz && mv or-tools_flatzinc_Ubuntu-18.04-64bit_v7.6.7691/bin/fzn-or-tools /usr/local/bin && mv or-tools_flatzinc_Ubuntu-18.04-64bit_v7.6.7691/share/minizinc/ or-tools_flatzinc_Ubuntu-18.04-64bit_v7.6.7691/share/ortools && mv or-tools_flatzinc_Ubuntu-18.04-64bit_v7.6.7691/share/ortools/ /usr/local/share/minizinc && rm -rf /usr/local/lib  && mv or-tools_flatzinc_Ubuntu-18.04-64bit_v7.6.7691/lib/ /usr/local/share/minizinc/lib && echo '{ \n\
-  "id": "com.google.or-tools",\n\
-  "name": "OR-Tools",\n\
-  "description": "OR Tools Constraint Programming Solver (from Google)",\n\
-  "version": "7.6.0",\n\
-  "mznlib": "-Gortools",\n\
-  "executable": "../../../bin/fzn-or-tools",\n\
-  "tags": ["cp","int", ],\n\
-  "stdFlags": ["-a","-n","-s","-v","-p","-f","-t"],\n\
-  "supportsMzn": false,\n\
-  "supportsFzn": true,\n\
-  "needsSolns2Out": true,\n\
-  "needsMznExecutable": false,\n\
-  "needsStdlibDir": false,\n\
-  "isGUIApplication": false \n\
-}' >> /usr/local/share/minizinc/solvers/or-tools.msc && rm -rf or-tools_flatzinc_Ubuntu-18.04-64bit_v7.6.7691/ && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/share/minizinc/lib && echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/share/minizinc/lib' >> ~/.bashrc && echo $LD_LIBRARY_PATH
-
+COPY --from=BUILDER /ortools/ /usr/local/

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Check it out and pull it at https://hub.docker.com/r/juanmarcos935/minizinc-or-t
 
 It is pretty easy. Inside the container running the image (doing something like `docker exec -it <your_container_name_or_id> /bin/bash`) you can easily from command line:
 
-`minizinc --solver or-tools <your_model>.mzn`
+`minizinc <your_model>.mzn <your_data>.dzn`
 
-That will force MiniZinc to solve your model using OR-Tools instead of Gecode (solver by default).
+Within this image OR-Tools is setup to be the default solver. Optionally you can use the `--solver <or-tools/gecode/coinbc/chuffed>` flag to select a specific solver included in the image image.
 
 Pull requests and commentaries for improving the Dockerfile are received.


### PR DESCRIPTION
Thank you for your work on a MiniZinc / OR-Tools docker image. I think it will be helpful for the MiniZinc community. When I looked at the image itself I saw some opportunity for improvement.

I see you have taken great care to ensure that the image itself will only add one layer to the resulting Docker image. Although that is great, actually writing in one RUN command makes the image very hard to maintain. In this PR I have changed the image to use a build environment which won't be included in the final image. This ensures that there is still only one layer added (the final COPY), but the Dockerfile is a lot easier to read and change.

At the same time I've change the OR-Tools version and revision to be Docker arguments. This means that you can provide them either by updating them in one place in the docker image or change them using the `--build-arg` docker flag.

Finally, I've also changed the default MiniZinc solver in the image to be OR-Tools. This means you no longer have to provide the `--solver or-tools` flag when calling `minizinc`